### PR TITLE
[JARS-90] Support resource upload through API

### DIFF
--- a/cookies/views/resource.py
+++ b/cookies/views/resource.py
@@ -6,6 +6,7 @@ from django.http import HttpResponseRedirect, HttpResponse, JsonResponse, QueryD
 from django.http import HttpResponseBadRequest
 from django.shortcuts import render, get_object_or_404
 from django.db.models import Q, Max
+from django.db import transaction
 from django.utils.http import urlquote_plus
 
 from cookies.models import *
@@ -198,7 +199,8 @@ def create_resource_file(request):
 
         form = UserResourceFileForm(request.POST, request.FILES)
         if form.is_valid():
-            content = _create_resource_file(request, request.FILES['upload_file'])
+            with transaction.atomic():
+                content = _create_resource_file(request, request.FILES['upload_file'])
             return HttpResponseRedirect(reverse('create-resource-details',
                                                 args=(content.id,)))
 
@@ -268,7 +270,8 @@ def create_resource_details(request, content_id):
         form = UserResourceForm(request.POST)
         if form.is_valid():
             resource_data = copy.copy(form.cleaned_data)
-            resource = _create_resource_details(request, content_resource, resource_data)
+            with transaction.atomic():
+                resource = _create_resource_details(request, content_resource, resource_data)
             return HttpResponseRedirect(reverse('resource', args=(resource.id,)))
 
     context.update({

--- a/cookies/views/resource.py
+++ b/cookies/views/resource.py
@@ -30,6 +30,61 @@ def _add_parameter(uri, key, value):
     parts[4] = urllib.urlencode(q)
     return urlparse.urlunparse(tuple(parts))
 
+def _create_resource_file(request, uploaded_file):
+    container = ResourceContainer.objects.create(created_by=request.user)
+    content = Resource.objects.create(**{
+        'content_type': uploaded_file.content_type,
+        'content_resource': True,
+        'name': uploaded_file._name,
+        'created_by': request.user,
+        'container': container,
+    })
+    collection = request.GET.get('collection')
+    if collection:
+        container.part_of_id = collection
+        container.save()
+
+    operations.add_creation_metadata(content, request.user)
+    # The file upload handler needs the Resource to have an ID first,
+    #  so we add the file after creation.
+    content.file = uploaded_file
+    content.save()
+    return content
+
+def _create_resource_details(request, content_resource, resource_data):
+    resource_data['entity_type'] = resource_data.pop('resource_type')
+    collection = resource_data.pop('collection', None)
+    if not content_resource.container:
+        content_resource.container = ResourceContainer.objects.create(created_by=request.user, part_of=collection)
+        content_resource.save()
+    else:
+        content_resource.container.part_of = collection
+
+    resource_data['created_by'] = request.user
+    resource_data['container'] = content_resource.container
+    resource = Resource.objects.create(**resource_data)
+    content_resource.container.primary = resource
+    content_resource.container.save()
+
+    operations.add_creation_metadata(resource, request.user)
+    content_relation = ContentRelation.objects.create(**{
+        'for_resource': resource,
+        'content_resource': content_resource,
+        'content_type': content_resource.content_type,
+        'container': content_resource.container,
+    })
+    resource.container = content_resource.container
+    resource.save()
+
+    if resource_data.get('public'):
+        ResourceAuthorization.objects.create(
+            granted_by = request.user,
+            granted_to = None,
+            action = ResourceAuthorization.VIEW,
+            policy = ResourceAuthorization.ALLOW,
+            for_resource = resource.container
+        )
+    return resource
 
 @auth.authorization_required(ResourceAuthorization.VIEW, _get_resource_by_id)
 def resource(request, obj_id):
@@ -143,25 +198,7 @@ def create_resource_file(request):
 
         form = UserResourceFileForm(request.POST, request.FILES)
         if form.is_valid():
-            uploaded_file = request.FILES['upload_file']
-            container = ResourceContainer.objects.create(created_by=request.user)
-            content = Resource.objects.create(**{
-                'content_type': uploaded_file.content_type,
-                'content_resource': True,
-                'name': uploaded_file._name,
-                'created_by': request.user,
-                'container': container,
-            })
-            collection = request.GET.get('collection')
-            if collection:
-                container.part_of_id = collection
-                container.save()
-
-            operations.add_creation_metadata(content, request.user)
-            # The file upload handler needs the Resource to have an ID first,
-            #  so we add the file after creation.
-            content.file = uploaded_file
-            content.save()
+            content = _create_resource_file(request, request.FILES['upload_file'])
             return HttpResponseRedirect(reverse('create-resource-details',
                                                 args=(content.id,)))
 
@@ -231,40 +268,7 @@ def create_resource_details(request, content_id):
         form = UserResourceForm(request.POST)
         if form.is_valid():
             resource_data = copy.copy(form.cleaned_data)
-            resource_data['entity_type'] = resource_data.pop('resource_type', None)
-            collection = resource_data.pop('collection', None)
-            if not content_resource.container:
-                content_resource.container = ResourceContainer.objects.create(created_by=request.user, part_of=collection)
-                content_resource.save()
-            else:
-                content_resource.container.part_of = collection
-
-            resource_data['created_by'] = request.user
-            resource_data['container'] = content_resource.container
-            resource = Resource.objects.create(**resource_data)
-            content_resource.container.primary = resource
-            content_resource.container.save()
-
-            operations.add_creation_metadata(resource, request.user)
-            content_relation = ContentRelation.objects.create(**{
-                'for_resource': resource,
-                'content_resource': content_resource,
-                'content_type': content_resource.content_type,
-                'container': content_resource.container,
-            })
-            resource.container = content_resource.container
-            resource.save()
-
-            if resource_data.get('public'):
-                ResourceAuthorization.objects.create(
-                    granted_by = request.user,
-                    granted_to = None,
-                    action = ResourceAuthorization.VIEW,
-                    policy = ResourceAuthorization.ALLOW,
-                    for_resource = resource.container
-                )
-
-
+            resource = _create_resource_details(request, content_resource, resource_data)
             return HttpResponseRedirect(reverse('resource', args=(resource.id,)))
 
     context.update({

--- a/cookies/views_rest.py
+++ b/cookies/views_rest.py
@@ -3,6 +3,7 @@ from django.conf.urls import url, include
 from django.contrib.auth.models import User
 from django.http import HttpResponse, HttpResponseRedirect, HttpResponseForbidden
 from django.shortcuts import get_object_or_404
+from django.db import transaction
 from rest_framework import routers, serializers, viewsets, reverse, renderers, mixins
 from rest_framework.views import APIView
 from rest_framework.parsers import JSONParser, FileUploadParser, MultiPartParser, FormParser
@@ -509,9 +510,9 @@ class ResourceViewSet(MultiSerializerViewSet):
         resource_data = serializer.validated_data
         uploaded_file = resource_data.pop('upload_file')
 
-        content_resource = _create_resource_file(request, uploaded_file)
-        resource = _create_resource_details(request, content_resource, resource_data)
-
+        with transaction.atomic():
+            content_resource = _create_resource_file(request, uploaded_file)
+            resource = _create_resource_details(request, content_resource, resource_data)
         return Response({'id': resource.id})
 
 

--- a/cookies/views_rest.py
+++ b/cookies/views_rest.py
@@ -5,7 +5,7 @@ from django.http import HttpResponse, HttpResponseRedirect, HttpResponseForbidde
 from django.shortcuts import get_object_or_404
 from rest_framework import routers, serializers, viewsets, reverse, renderers, mixins
 from rest_framework.views import APIView
-from rest_framework.parsers import JSONParser, FileUploadParser, MultiPartParser
+from rest_framework.parsers import JSONParser, FileUploadParser, MultiPartParser, FormParser
 from rest_framework.response import Response
 from rest_framework.decorators import detail_route, list_route, api_view, parser_classes
 from rest_framework.permissions import IsAuthenticated, BasePermission
@@ -15,6 +15,7 @@ import django_filters
 
 from guardian.shortcuts import get_objects_for_user
 from django.db.models import Q
+from django.core.exceptions import ObjectDoesNotExist
 
 from cookies.http import HttpResponseUnacceptable, IgnoreClientContentNegotiation
 
@@ -22,12 +23,15 @@ import magic
 import re
 from collections import OrderedDict
 
+import cookies.models
 from cookies import authorization, tasks, giles
 from cookies.accession import get_remote
 from cookies.aggregate import aggregate_content_resources, aggregate_content_resources_fast
 from cookies.models import *
 from concepts.models import *
 from cookies.exceptions import *
+from cookies import giles, operations
+from cookies.views.resource import _create_resource_file, _create_resource_details
 
 
 from django.utils.decorators import method_decorator
@@ -403,14 +407,59 @@ class FieldViewSet(viewsets.ModelViewSet):
     filter_class = FieldFilter
 
 
+class TypeField(serializers.Field):
+    def to_internal_value(self, data):
+        splits = map(lambda x: x.strip(), data.split(':'))
+        if len(splits) > 2:
+            raise serializers.ValidationError('Invalid type value format')
+        elif len(splits) == 1:
+            kwargs = {
+                'name': splits[0]
+            }
+        elif len(splits) == 2:
+            kwargs = {
+                'schema__name': splits[0],
+                'name': splits[1],
+            }
+        try:
+            t = cookies.models.Type.objects.get(**kwargs)
+        except ObjectDoesNotExist, e:
+            raise ValidationError('Type value doesn\'t exist')
+        return t
+
+
+class CollectionField(serializers.Field):
+    def to_internal_value(self, data):
+        request = self.context['request']
+        collection = authorization.apply_filter(*(
+            CollectionAuthorization.ADD,
+            request.user,
+            cookies.models.Collection.objects.filter(name=data).order_by('name')
+        ))
+        if len(collection) < 1:
+            raise ValidationError('Collection doesn\'t exist')
+        return collection[0]
+
+
+class CreateResourceSerializer(serializers.Serializer):
+    name = serializers.CharField()
+    upload_file = serializers.FileField()
+    public = serializers.BooleanField(required=False)
+    uri = serializers.CharField(required=False)
+    description = serializers.CharField(required=False)
+    resource_type = TypeField()
+    collection = CollectionField(required=False)
+
+
 class ResourceViewSet(MultiSerializerViewSet):
-    parser_classes = (JSONParser,)
+    parser_classes = (JSONParser, MultiPartParser, FormParser,)
     queryset = Resource.active.filter(hidden=False)
 
     serializers = {
         'list': ResourceListSerializer,
         'retrieve':  ResourceDetailSerializer,
         'default':  ResourceListSerializer,
+        'create': CreateResourceSerializer,
     }
     permission_classes = (ResourcePermission,)
 
@@ -453,6 +502,17 @@ class ResourceViewSet(MultiSerializerViewSet):
             qs = qs.filter(Q(content__content_resource__content_type=content_type))
         return qs
 
+    def create(self, request):
+        serializer = CreateResourceSerializer(data=request.data, context={'request': request})
+        serializer.is_valid(raise_exception=True)
+
+        resource_data = serializer.validated_data
+        uploaded_file = resource_data.pop('upload_file')
+
+        content_resource = _create_resource_file(request, uploaded_file)
+        resource = _create_resource_details(request, content_resource, resource_data)
+
+        return Response({'id': resource.id})
 
 
 # TODO: refactor or scrap this.
@@ -513,3 +573,4 @@ class ResourceContentView(APIView):
         resource.save()
 
         return Response(status=204)
+


### PR DESCRIPTION
Update 'resource' REST API end-point to support
creation of a new resource. Support resource
content upload using the same API end-point.