### PR TITLE
[JARS-111] Enable upload polling only on Giles ack

### DIFF
--- a/cookies/giles.py
+++ b/cookies/giles.py
@@ -287,7 +287,9 @@ def send_giles_upload(upload_pk, username):
 
     try:
         code, result = send_to_giles(username, upload.file_path, public=False)
-        upload.upload_id = result.get('id')
+        if code != 200:
+            raise RuntimeError('Giles returned HTTP {}'.format(code))
+        upload.upload_id = result['id']
         upload.state = GilesUpload.SENT
     except AttributeError as E:
         message = str(result)


### PR DESCRIPTION
Enable polling of Giles uploads only when Giles
returns a 200 OK response acknowledging the upload
request.