### PR TITLE
[JARS-111] Ensure upload state's updated on errors

### DIFF
--- a/cookies/giles.py
+++ b/cookies/giles.py
@@ -515,6 +515,12 @@ def process_upload(upload_id, username):
         upload.save()
         return
 
+    if code >= 400:
+        upload.message = str(data)
+        upload.state = GilesUpload.GILES_ERROR
+        upload.save()
+        return
+
     try:
         # If Giles is done processing the upload, details about the resulting
         #  files are returned.


### PR DESCRIPTION
Ensure Giles upload state is updated to the relevant
error state to avoid indefinite polling.