### PR TITLE
[JARS-118] Handle duplicate filenames

### DIFF
--- a/cookies/accession/giles.py
+++ b/cookies/accession/giles.py
@@ -56,7 +56,11 @@ class GilesRemote(object):
         """
         """
         headers = self.build_auth_headers()
-        response = requests.get(self.sign_uri(target), headers=headers)
+
+        # Giles doesn't return images if 'dw' parameter is missing
+        params = {'dw': 500}
+
+        response = requests.get(self.sign_uri(target), params=params, headers=headers)
         if response.status_code != 200:
             raise IOError('Giles responded with %i: %s' % (response.status_code, response.content))
         if raw:

--- a/cookies/giles.py
+++ b/cookies/giles.py
@@ -744,7 +744,7 @@ def process_details(data, upload_id, username):
             pages[page_nr][fmt] = content_resource
 
         name_fn = lambda d: '%s - %s (%s)' % (page_resource.name, d.get('id'),
-                                              d.get('content_type'))
+                                              d.get('content-type'))
         # Content resource for each additional file, if available.
         _create_additional_files_resources(page_data.get('additionalFiles', []),
                                            page_resource,

--- a/cookies/templates/collection.html
+++ b/cookies/templates/collection.html
@@ -23,22 +23,26 @@
         {% if can_edit_resource %}
         <a class="btn glyphicon glyphicon-pencil" aria-hidden="true"
             href="{% url "collection-edit" collection.id %}"
-            data-toggle="tooltip"
-            data-title="Edit collection"></a>
+            title="Edit collection"></a>
         {% endif %}
         {% is_authorized "collection_view_auth" user collection as can_view_authorizations %}
         {% if can_view_authorizations %}
         <a class="btn glyphicon glyphicon-lock" aria-hidden="true"
             href="{% url "collection-authorizations" collection.id %}"
-            data-toggle="tooltip"
-            data-title="Authorizations"></a>
+            title="Authorizations"></a>
         {% endif %}
         {% if can_edit_resource %}
 
             <a class="btn glyphicon glyphicon-plus"
-                href="{% url "create-collection" %}?parent_collection={{ collection.id }}"></a>
+               title="Create sub-collection"
+               href="{% url "create-collection" %}?parent_collection={{ collection.id }}"></a>
 
         {% endif %}
+        <a class="btn glyphicon glyphicon-hdd"
+           href="{% url "create-dataset" %}?filter_parameters=collection%3D{{ collection.id }}"
+           style="text-decoration:underline; text-decoration-style:double;"
+           title="Create dataset from this collection">
+        </a>
     </span>
     <div class="h3 collection_name">{{ collection.name }}</div>
     <p>

--- a/cookies/templates/create_dataset.html
+++ b/cookies/templates/create_dataset.html
@@ -21,7 +21,9 @@
         Use datasets to define groups of resources for future reference.
     </p>
     <p class="text-warning">
-        You have selected {{ resource_count|intcomma }} resources.
+        You have selected
+        {% if collection_count %} {{ collection_count|intcomma }} collection(s) {% endif %}
+        {% if resource_count %} {% if collection_count %} and {% endif %} {{ resource_count|intcomma }} resource(s). {% endif %}
     </p>
 </div>
 <div class="container-fluid">

--- a/cookies/templates/dataset.html
+++ b/cookies/templates/dataset.html
@@ -29,7 +29,9 @@
         <dd>{{ dataset.updated }}</dd>
         <dt>Type</dt>
         <dd>{{ dataset.get_dataset_type_display }} </dd>
-        <dt>Size</dt>
+        <dt>Collections count</dt>
+        <dd>{{ collection_count|intcomma }} </dd>
+        <dt>Resources count</dt>
         <dd>{{ resource_count|intcomma }} </dd>
     </dl>
 

--- a/cookies/templates/fragment_resource_list.html
+++ b/cookies/templates/fragment_resource_list.html
@@ -26,7 +26,7 @@
           {% if filter_parameters and user.is_authenticated %}
           <a class="btn btn-xs"
              href="{% url "create-dataset" %}?filter_parameters={{ filter_parameters }}">
-              <span class="glyphicon glyphicon-hdd"></span> Create Dataset
+              <span class="glyphicon glyphicon-hdd"></span> Create Dataset from filters
           </a>
           {% endif %}
       </div>


### PR DESCRIPTION
Filenames can be repeated while exporting resources
in a dataset. Ensure both the files are present in the
exported dataset zip file.