### PR TITLE
[JARS-141] Empty text should not be created

### DIFF
--- a/cookies/views/resource.py
+++ b/cookies/views/resource.py
@@ -126,13 +126,8 @@ def resource_list(request):
     Display all :class:`.Resource` instances to which the user has access.
     """
 
-    # Check for removing empty text
-    print list(ResourceContainer.objects.values_list('primary_id', flat=True))
-    if None in ResourceContainer.objects.values_list('primary_id'):
-        print "Found"
-        for resource_container in ResourceContainer.objects.all():
-            if resource_container.primary_id is None:
-                resource_container.delete()
+    # Check for removing empty text. Find and delete entries which do not have a primary id
+    ResourceContainer.objects.filter(primary_id=None).delete()
 
     resources = auth.apply_filter(ResourceAuthorization.VIEW, request.user,
                                   ResourceContainer.active.all())

--- a/cookies/views/resource.py
+++ b/cookies/views/resource.py
@@ -126,6 +126,14 @@ def resource_list(request):
     Display all :class:`.Resource` instances to which the user has access.
     """
 
+    # Check for removing empty text
+    print list(ResourceContainer.objects.values_list('primary_id', flat=True))
+    if None in ResourceContainer.objects.values_list('primary_id'):
+        print "Found"
+        for resource_container in ResourceContainer.objects.all():
+            if resource_container.primary_id is None:
+                resource_container.delete()
+
     resources = auth.apply_filter(ResourceAuthorization.VIEW, request.user,
                                   ResourceContainer.active.all())
 
@@ -191,10 +199,10 @@ def create_resource_file(request):
         form = UserResourceFileForm(request.POST, request.FILES)
         if form.is_valid():
             with transaction.atomic():
+                print request.FILES['upload_file'], Resource.objects.latest('id')
                 content = _create_resource_file(request, request.FILES['upload_file'], Resource.INTERFACE_WEB)
             return HttpResponseRedirect(reverse('create-resource-details',
                                                 args=(content.id,)))
-
     context.update({'form': form})
     return render(request, 'create_resource_file.html', context)
 

--- a/cookies/views/resource.py
+++ b/cookies/views/resource.py
@@ -194,7 +194,6 @@ def create_resource_file(request):
         form = UserResourceFileForm(request.POST, request.FILES)
         if form.is_valid():
             with transaction.atomic():
-                print request.FILES['upload_file'], Resource.objects.latest('id')
                 content = _create_resource_file(request, request.FILES['upload_file'], Resource.INTERFACE_WEB)
             return HttpResponseRedirect(reverse('create-resource-details',
                                                 args=(content.id,)))

--- a/jars/settings.py
+++ b/jars/settings.py
@@ -89,7 +89,7 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         # 'rest_framework.authentication.BasicAuthentication',
         'rest_framework.authentication.TokenAuthentication',
-        'oauth2_provider.contrib.rest_framework.OAuth2Authentication',
+        'oauth2_provider.ext.rest_framework.OAuth2Authentication',
         'jars.auth.GithubTokenBackend',
         'rest_framework.authentication.SessionAuthentication',
     ),

--- a/jars/settings.py
+++ b/jars/settings.py
@@ -89,7 +89,7 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         # 'rest_framework.authentication.BasicAuthentication',
         'rest_framework.authentication.TokenAuthentication',
-        'oauth2_provider.ext.rest_framework.OAuth2Authentication',
+        'oauth2_provider.contrib.rest_framework.OAuth2Authentication',
         'jars.auth.GithubTokenBackend',
         'rest_framework.authentication.SessionAuthentication',
     ),


### PR DESCRIPTION
When uploading a text there are two phases to it - 
1. Uploading a file
2. Adding details about the file

The empty text is created when a user does the first action but does not follow through properly with the second action. This can be done if a user clicks on a different link, or opens a new url before submitting the details about the uploaded file. 

These two actions are coded in two different functions. For now, I have added a check on the page which populates the resources. Entry will be deleted if there is no corresponding primary_id for it.  